### PR TITLE
Reference models, allow multiple models per config. Closes #57

### DIFF
--- a/deva/references.py
+++ b/deva/references.py
@@ -1,0 +1,149 @@
+'''Reference "models" for conceptual aid.'''
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils import check_array, check_X_y
+from sklearn.utils.validation import check_is_fitted
+from sklearn.preprocessing import LabelBinarizer
+
+
+class RandomClassifier(BaseEstimator, ClassifierMixin):
+    '''Random classifier for predicting randomly using the label base rate.
+
+    If a sensitive attribute is provided, then this class will also stratify
+    the base rates based on this attribute.
+
+    Parameters
+    ----------
+    stratify_attribute: int, str, optional
+        This is an integer or string specifying the column index into X of the
+        attribute to use to compute the base rates. If this is None, then the
+        base rate of labels is used for all of the data. Otherwise this column
+        will indicate how to split the labels into different groups, and a base
+        rate for each group will be computed.
+
+    Note
+    ----
+    This only works on binary labels so far.
+    '''
+
+    def __init__(
+        self,
+        stratify_attribute=None
+    ):
+        '''Construct a random classifier object.'''
+        if not isinstance(stratify_attribute, (str, int)) and \
+                stratify_attribute is not None:
+            raise TypeError('stratify_attribute must be a string or integer')
+        self.stratify_attribute = stratify_attribute
+
+    def fit(self, X, y):
+        '''Fit a random classifier.
+
+        Parameters
+        ----------
+        X: ndarray or DataFrame
+            A shape (N, D) array of covariates. If stratify_attribute has been
+            specified, then this specifies the column into X of the attribute
+            to use for label stratification.
+        y: ndarray
+            The labels used to compute the base rates.
+        '''
+        self.labelenc_ = LabelBinarizer()
+        if isinstance(self.stratify_attribute, str):
+            if not hasattr(X, 'columns'):
+                raise TypeError('X has to be a DataFrame,'
+                                'or use int stratify_attribute')
+            self.sens_col_ = list(X.columns).index(self.stratify_attribute)
+        else:
+            self.sens_col_ = self.stratify_attribute
+        X, y = check_X_y(X, y)
+
+        ye = self.labelenc_.fit_transform(y)
+        if len(self.labelenc_.classes_) != 2:
+            raise ValueError('RandomClassifier only works with binary labels.')
+
+        if self.stratify_attribute is None:
+            self.py_ = ye.mean()
+        else:
+            A = X[:, self.sens_col_]
+            self.a_classes_ = set(A)
+            self.py_ = [y[A == a].mean() for a in self.a_classes_]
+
+        return self
+
+    def predict(self, X):
+        '''Use a random classifier for prediction.
+
+        Parameters
+        ----------
+        X: ndarray or DataFrame
+            A shape (N, D) array of covariates. If stratify_attribute has been
+            specified, then this specifies the column into X of the attribute
+            to use for label stratification. This will change the probability
+            of predicting y==1 for each attribute class.
+
+        Returns
+        -------
+        y: ndarray
+            An array of shape (N,) of predictions. These predictions are
+            random, with a probability defined by the training label base rates
+            (for each sensitive attribute if stratify_attribute has been set).
+        '''
+        py = self.predict_proba(X)[:, 1]
+        y_hat = np.random.binomial(n=1, p=py)
+        return self.labelenc_.inverse_transform(y_hat)
+
+    def predict_proba(self, X):
+        '''Use a random classifier for probabilistic prediction.
+
+        Parameters
+        ----------
+        X: ndarray or DataFrame
+            A shape (N, D) array of covariates. If stratify_attribute has been
+            specified, then this specifies the column into X of the attribute
+            to use for label stratification. This will change the probability
+            of predicting y==1 for each attribute class.
+
+        Returns
+        -------
+        py: ndarray
+            An array of shape (N, 2) of class probability predictions. These
+            probabilities are the (unconditional) base rate probabilities, p(y)
+            defined by the training label base rates. If stratify_attribute is
+            not None, then these are conditional, p(y|a), where a is the
+            attribute.
+        '''
+        check_is_fitted(self, attributes=['py_'])
+        X = check_array(X)
+        n = len(X)
+
+        py = np.zeros((n, len(self.labelenc_.classes_)))
+        if self.stratify_attribute is None:
+            py[:, 1] = self.py_
+            py[:, 0] = 1 - self.py_
+            return py
+
+        A = X[:, self.sens_col_]
+        for i, a in enumerate(self.a_classes_):
+            py[A == a, 1] = self.py_[i]
+        py[:, 0] = 1. - py[:, 1]
+
+        return py
+
+    def get_params(self, deep=True):
+        """Get this estimator's initialisation parameters."""
+        return {
+            'stratify_attribute': self.stratify_attribute
+        }
+
+    def set_params(self, **parameters):
+        """Set this estimator's initialisation parameters."""
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self
+
+    def _get_tags(self):
+        tags = super()._get_tags()
+        tags['binary_only'] = True  # tell sklearn API this is binary only
+        return tags

--- a/scenarios/example/model.toml
+++ b/scenarios/example/model.toml
@@ -34,6 +34,7 @@ FP = 0
 TN = 1
 FN = -10
 
+
 # The name here must match the dictionary entry in deva/model.py iter_models
 # function. This tells the program what model you want to use.  In this
 # section, put default hyperparametrs that will apply to all draws. They may be
@@ -81,3 +82,16 @@ positive_class_weight = 20
 random_state = 2
 tol = 1.2e-4
 positive_class_weight = 10
+
+[randomclassifier]
+[randomclassifier.instances.random]
+stratify_attribute = "customer_is_female"
+
+[dummyclassifier]
+[dummyclassifier.instances.positive]
+strategy = "constant"
+constant = 1
+
+[dummyclassifier.instances.negative]
+strategy = "constant"
+constant = 0

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,69 @@
+'''Test the reference models.'''
+import pytest
+import numpy as np
+import pandas as pd
+# from sklearn.utils.estimator_checks import check_estimator
+
+from deva.references import RandomClassifier
+
+
+def within_one_percent(pred, true):
+    return np.abs(pred - true) / true < 1e-2
+
+
+# Getting this working is more effort than it is worth.
+# def test_estimator():
+#     est = RandomClassifier()
+#     check_estimator(est)
+
+
+def test_no_sensitive(random):
+    '''Test random predictor with no stratification.'''
+    p_true = 0.2
+    n = 500000
+    X = random.randn(n, 2)  # This doesn't do anything
+    y = random.binomial(n=1, p=p_true, size=n)
+
+    clf = RandomClassifier()
+    clf.fit(X, y)
+    assert within_one_percent(clf.py_, p_true)
+    assert np.allclose(clf.py_, clf.predict_proba(X)[:, 1])
+
+    y_hat = clf.predict(X)
+    p_hat = np.mean(y_hat)
+    assert not np.allclose(y, y_hat)
+    assert within_one_percent(clf.py_, p_hat)
+
+
+@pytest.mark.parametrize('attr', ['protected', 1])
+def test_stratification(random, attr):
+    '''Test sensitive attribute stratification.'''
+    n = 500000
+    pa = 0.3
+    py = 0.4
+    pya = 0.6
+    X = pd.DataFrame({
+        'something random': random.randn(n),
+        'protected': random.binomial(n=1, p=pa, size=n)
+    })
+    amask = X['protected'] == 1
+    na = amask.sum()
+    y = np.empty(n)
+    y[amask] = random.binomial(n=1, p=pya, size=na)
+    y[~amask] = random.binomial(n=1, p=py, size=n-na)
+
+    clf = RandomClassifier(stratify_attribute=attr)
+    clf.fit(X, y)
+    assert isinstance(clf.py_, list)
+    assert within_one_percent(clf.py_[0], py)
+    assert within_one_percent(clf.py_[1], pya)
+
+    p_pred = clf.predict_proba(X)[:, 1]
+    assert np.allclose(clf.py_[0], p_pred[~amask])
+    assert np.allclose(clf.py_[1], p_pred[amask])
+
+    y_hat = clf.predict(X)
+    pa_hat = np.mean(y_hat[amask])
+    p_hat = np.mean(y_hat[~amask])
+    assert within_one_percent(clf.py_[0], p_hat)
+    assert within_one_percent(clf.py_[1], pa_hat)


### PR DESCRIPTION
- Makes a `RandomClassifier` reference model - this can randomly produce labels based on the base rates per sensitive group
- Incorporates sklearns `DummyClassifier`s into the model.py dictionary. This allows for a number of naive classifiers
- Extends the model iterators to allow for multiple models to be specified in the one model.toml config file.