### PR TITLE
Tweak scrollbar visuals with new frontend

### DIFF
--- a/server/deva-ts/src/Constrain.tsx
+++ b/server/deva-ts/src/Constrain.tsx
@@ -22,7 +22,7 @@ const HandleColours = {
 }
 
 const BackgroundColours = {
-  0: 'gray-600',  // default
+  0: 'gray-700',  // default
   1: 'gray-700',  // blocked
   2: 'pink-900',  // blocking
   3: 'green-900', // resolvedBlock
@@ -121,6 +121,8 @@ function DescriptionRangeConstraint({uid, unit}) {
   const lowerIsBetter = unit.lowerIsBetter === false ? false : true;
   const maxRanges = useRecoilValue(maxRangesState);
   const constraints = useRecoilValue(constraintsState);
+  const bgcolor = GetBackgroundColor(uid);
+
   const pane = (unit.type === "qualitative") ? 
 
     (<QualitativeConstraint u={unit} 
@@ -136,7 +138,7 @@ function DescriptionRangeConstraint({uid, unit}) {
       lowerIsBetter={lowerIsBetter}/>)
 
   return (
-    <div className="grid grid-cols-8 bg-gray-700">
+    <div className={"grid grid-cols-8 " + bgcolor}>
       <div className="col-span-3">
         <UnitDescription uid={uid} unit={unit} />
       </div>
@@ -191,7 +193,7 @@ function QuantitativeConstraint({u, maxRanges, constraints, uid, lowerIsBetter})
 
   return (
     <div key={uid} 
-    className={"grid grid-cols-5 gap-8 p-4"}>
+    className={"grid grid-cols-5 gap-8 p-4 " + bgcolor}>
       
       <p className="col-span-5 text-xl text-center">{cstring}</p>
 
@@ -222,7 +224,7 @@ function QualitativeConstraint({u, maxRanges, constraints, uid, lowerIsBetter}) 
   )
 
   return (
-    <div key={uid} className="py-10 px-20">
+    <div key={uid} className={"py-15 px-20 " + bgcolor}>
         <RangeConstraint uid={uid} min={min} max={max} marks={marks} decimals={null} lowerIsBetter={lowerIsBetter}/>
     </div>
   )
@@ -317,7 +319,9 @@ function RangeConstraint({uid, min, max, marks, decimals, lowerIsBetter}) {
       blockedStatus={blockedStatus} lowerIsBetter={lowerIsBetter}/>
     <Slider {...rangeProps} />
     <OptimalDirection lowerIsBetter={lowerIsBetter}/>
-    {button}
+    <div className="text-center">
+      {button}
+    </div>
   </div>
   );
 }
@@ -443,7 +447,7 @@ function UnblockButton({uid, buttonDisabled}) {
     : "suggest metrics to unblock";
 
   return (
-    <button className="btn text-xl uppercase py-2 px-8 font-bold rounded-lg"
+    <button className="btn text-l uppercase py-2 px-6 font-bold rounded-lg"
       onClick={() => {
         if (blockedMetric === uid) {
           setBlockedMetric(null);


### PR DESCRIPTION
* Centered blocking status
* Have default colour for suggestions match new default colour
* Reimplement background colours for unblocking suggestions

If just have gray background is preferred for unblocking suggestions, we will just have to fix the colours for the unblocking target bar to match that (could be a potential visual setting in configurations)